### PR TITLE
fix(Admin): Open Command Not Working

### DIFF
--- a/resources/[mercy]/mercy-admin/client/cl_functions.lua
+++ b/resources/[mercy]/mercy-admin/client/cl_functions.lua
@@ -5,7 +5,7 @@
 function InitAdminMenu()
     if PlayerModule.IsPlayerAdmin() then DebugPrint('permission', Lang:t("info.has_perm")) else DebugPrint('permission', Lang:t("info.has_no_perm")) end
     if (GetServerConvar('steam_webApiKey') == 'none') then DebugPrint('steam', Lang:t("info.steam_key")) end
-    KeybindsModule.Add("openAdminMenu", 'Admin', Lang:t('info.keymapping_desc'), '', nil, 'mc-admin/client/try-open-menu')
+    KeybindsModule.Add("openAdminMenu", 'Admin', Lang:t('info.keymapping_desc'), Config.Settings['DefaultOpenKeybind'], nil, 'mc-admin/client/try-open-menu')
     KeybindsModule.Add("toggleNoclip", 'Admin', 'Toggle Noclip', '', nil, 'mercy-admin/client/toggle-noclip')
     Citizen.Wait(100)
     RefreshMenu('all')

--- a/resources/[mercy]/mercy-admin/server/sv_main.lua
+++ b/resources/[mercy]/mercy-admin/server/sv_main.lua
@@ -47,7 +47,7 @@ Citizen.CreateThread(function()
     end, 'admin')
 
     CommandsModule.Add(Config.Commands['MenuOpen'], Lang:t("info.keymapping_desc"), {}, false, function(source)
-        TriggerClientEvent('mc-admin/client/try-open-menu', source, false)
+        TriggerClientEvent('mc-admin/client/try-open-menu', source, true)
     end, 'admin')
 
     CommandsModule.Add(Config.Commands['MenuDebug'], Lang:t("info.menu_debug"), {}, false, function(source)


### PR DESCRIPTION
Fixed the admin menu open command not working and setup the Default open keybind as it was in the config and wasn't being used.