### PR TITLE
fix(UI/HUD): Hunger / Thirst Max Values

### DIFF
--- a/resources/[essentials]/mercy-ui/nui/Apps/Hud/js/main.js
+++ b/resources/[essentials]/mercy-ui/nui/Apps/Hud/js/main.js
@@ -175,6 +175,7 @@ Hud.addNuiListener('SetComponentValues', (Data) => {
                 Armor.trail.setAttribute("stroke", "rgba(21, 101, 192, 0.35)")
             }
         } else if (Key === 'Food' && CurrentHudValues.Food.Value != Value.Value && HudPreferences.ShowFood) {
+            if (Value.Value > 100) { Value.Value = 100; }
             Food.animate(Value.Value / 100);
             if (Value.Value <= 10) {
                 $('.hud-hunger').addClass('anim-fade-in-out');
@@ -184,6 +185,7 @@ Hud.addNuiListener('SetComponentValues', (Data) => {
                 Food.trail.setAttribute("stroke", "rgba(255, 109, 0, 0.35)")
             }
         } else if (Key === 'Water' && CurrentHudValues.Water.Value != Value.Value && HudPreferences.ShowWater) {
+            if (Value.Value > 100) { Value.Value = 100; }
             Water.animate(Value.Value / 100);
             if (Value.Value <= 10) {
                 $('.hud-thirst').addClass('anim-fade-in-out');

--- a/resources/[mercy]/mercy-items/server/sv_main.lua
+++ b/resources/[mercy]/mercy-items/server/sv_main.lua
@@ -837,14 +837,16 @@ Citizen.CreateThread(function()
     EventsModule.RegisterServer("mercy-items/server/add-food", function(Source, Amount)
         local Player = PlayerModule.GetPlayerBySource(Source)
         if Player then
-            Player.Functions.SetMetaData("Food", tonumber(Player.PlayerData.MetaData['Food']) + tonumber(Amount))
+            local NewValue = tonumber(Player.PlayerData.MetaData['Food']) + tonumber(Amount)
+            Player.Functions.SetMetaData("Food", math.min(NewValue, 100))
         end
     end)
     
     EventsModule.RegisterServer("mercy-items/server/add-water", function(Source, Amount)
         local Player = PlayerModule.GetPlayerBySource(Source)
         if Player then
-            Player.Functions.SetMetaData("Water", tonumber(Player.PlayerData.MetaData['Water']) + tonumber(Amount))
+            local NewValue = tonumber(Player.PlayerData.MetaData['Water']) + tonumber(Amount)
+            Player.Functions.SetMetaData("Water", math.min(NewValue, 100))
         end
     end)
     


### PR DESCRIPTION
Made it so the HUD doesn't go over 100 causing it to redo the circle as it's already full and added a math.min to the add-food & add-water modules so if it goes over 100 it's set back to 100.