### PR TITLE
Fix glitch with weigh limit

### DIFF
--- a/resources/[mercy]/mercy-inventory/server/sv_main.lua
+++ b/resources/[mercy]/mercy-inventory/server/sv_main.lua
@@ -135,6 +135,8 @@ AddEventHandler('Modules/server/ready', function()
 						if Player.Functions.AddItem(StoreItem['ItemName'], Amount, ToSlot, OtherInventoryItems[FromSlot].Info, false, 'Inventory') then
 							Cb(true)
 						else
+							Player.Functions.AddMoney('Cash', (StoreItem.Price * Amount))
+							Player.Functions.Notify('invalid-action', 'Failed to buy item. Maybe we are full ?', 'error')
 							Cb(false)
 						end
 					else


### PR DESCRIPTION
Fix a bug when you buy stack of  item that goes over your weight limit it will remove the money even on failed. 
now returns money and give notification