### PR TITLE
Fixed null object mercy-jobs

### DIFF
--- a/resources/[mercy]/mercy-jobs/client/_cl_main.lua
+++ b/resources/[mercy]/mercy-jobs/client/_cl_main.lua
@@ -1,5 +1,8 @@
 EntityModule, LoggerModule, EventsModule, CallbackModule, BlipModule, PedsModule, FunctionsModule, VehicleModule = nil, nil, nil, nil, nil, nil, nil, nil
-
+Jobs.Delivery = {
+    Location = nil,
+    HasPackage = false,
+}
 local _Ready = false
 AddEventHandler('Modules/client/ready', function()
     if not _Ready then
@@ -106,8 +109,8 @@ function SetupPeds()
             }
         }
     })
-    local Jobs = CallbackModule.SendCallback("mercy-phone/server/jobcenter/get-jobs")
-    for k, Job in pairs(Jobs) do
+    local JobsTable = CallbackModule.SendCallback("mercy-phone/server/jobcenter/get-jobs")
+    for k, Job in pairs(JobsTable) do
         exports['mercy-ui']:AddEyeEntry("job_ped_" .. Job['Name'] .. "_" .. k, {
             Type = 'Entity',
             EntityType = 'Ped',

--- a/resources/[mercy]/mercy-jobs/client/jobcenter/cl_delivery.lua
+++ b/resources/[mercy]/mercy-jobs/client/jobcenter/cl_delivery.lua
@@ -1,8 +1,3 @@
-Jobs.Delivery = {
-    Location = nil,
-    HasPackage = false,
-}
-
 -- [ Code ] --
 
 -- [ Events ] --


### PR DESCRIPTION
Changed Local declared Jobs to JobsTable because it screwed up the global defined Jobs in sh_config.lua
Also moved the declare of Jobs.Delivery to cl_main.lua due throwing an null object at current line 186. 

I have tested on my other fork of anubis and this fix made it work not sure what causing it, maybe it has something to do with the includes method via fxmanifest.lua ?