### PR TITLE
Fixed two bugs with mercy-illegal

### DIFF
--- a/resources/[mercy]/mercy-illegal/client/cl_plants.lua
+++ b/resources/[mercy]/mercy-illegal/client/cl_plants.lua
@@ -304,7 +304,7 @@ function GetStageFromPlant(Stage)
         return 3
     elseif Stage > 60 and Stage <= 80 then
         return 4
-    elseif Stage > 80 and Stage <= 100 then
+    elseif Stage > 80 then
         return 5
     end
 end

--- a/resources/[mercy]/mercy-illegal/shared/sh_config.lua
+++ b/resources/[mercy]/mercy-illegal/shared/sh_config.lua
@@ -72,23 +72,23 @@ Config.WeedRackDryTime = 2 -- 2 Minutes
 Config.ContainerWhitelist = { '9432', '7078' }
 
 Config.GrowthObjects = {
-    [0] = {
+    [1] = {
         ['Hash'] = GetHashKey('bkr_prop_weed_01_small_01b'),
         ['Z-Offset'] = -0.5,
     },
-    [1] = {
+    [2] = {
         ['Hash'] = GetHashKey('bkr_prop_weed_med_01a'),
         ['Z-Offset'] = -3.0,
     },
-    [2] = {
+    [3] = {
         ['Hash'] = GetHashKey('bkr_prop_weed_med_01b'),
         ['Z-Offset'] = -3.0,
     },
-    [3] = {
+    [4] = {
         ['Hash'] = GetHashKey('bkr_prop_weed_lrg_01a'),
         ['Z-Offset'] = -3.0,
     },
-    [4] = {
+    [5] = {
         ['Hash'] = GetHashKey('bkr_prop_weed_lrg_01b'),
         ['Z-Offset'] = -3.0,
     }


### PR DESCRIPTION
The first bug is related to Config.GrowthObjects: In the GetStageFromPlant function you return stages between 1 and 5, but the array had values between 0 and 4. At stage 5 it could not find the correct model to use.

The second bug is related to the GetStageFromPlant function. Because of the randomness in the plant growth (a value between 3 and 6) the number could be higher than 100. The function would then not return a stage at all.